### PR TITLE
Release 3.13

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,14 +1,17 @@
 3.13.1
 
-<!-- Thu, 16 Nov 2017 10:44:58 +0100 -->
+<!-- Thu, 30 Nov 2017 13:38:22 +0100 -->
 
 # Features
 
+ * Add app-parser() framework (automatic parsing of log messages) (#1689)
  * Support microseconds in Riemann destination (#1710)
  * Add osquery destination as an SCL plugin (#1728)
  * Add network load balancer destination (#1706)
  * Add possibility to only signal re-open of file handles (SIGUSR1) (#1530)
  * It is possible from now to limit the number of registered dynamic counters (#1743)
+ * Add $(binary) template function (#1679)
+ * Add experimental transport for transferring messages in whole between syslog-ng instances (EWMM) (#1689)
 
 # Bugfixes
 
@@ -29,6 +32,10 @@
  * Fix a crash when getent is used empty group (#1691)
  * Fix jvm-options() (#1704)
  * Fix a crash in Python language binding (#1694)
+ * Fix a crash in afmongodb (#1765)
+ * Fix a memory leak in afmongodb (#1766)
+ * Fix name-to-GID calculation in the $(getent) template function (#1764)
+ * Fix a crash when redis is configured without the command() option (#1767)
 
 # Other changes
 
@@ -36,10 +43,15 @@
  * Provide tls block for tls options in amqp(), http(), riemann() destination drivers (#1715)
  * It it possible from now to register blocks and generators as plugins (#1657)
  * Drop compatiblity with configurations below 3.0 (#1709)
+ * Do not change permissions of a file by default (#1782)
+ * Allow source files to specify permissions locally (#1782)
+ * Minor performance improvement (#1729)
+ * The current config version can be queried with "--version" (#1740)
 
 # Notes to the developers
 
  * Change configure default option for jsonc and mongoc from auto to internal (#1735)
+ * Disable ASLR when running unit tests (#1753)
 
 # Credits
 
@@ -53,6 +65,6 @@ of syslog-ng, contribute.
 We would like to thank the following people for their contribution:
 Andras Mitzki, Antal Nemes, Attila Szalay, Balazs Scheidler, Gabor Nagy,
 Jakub Jankowski, Janos Szigetvari, Laszlo Budai, Laszlo Varady, Laszlo Szemere,
-Marton Illes, Mate Farkas, Peter Kokai, Pontus Andersson, Sam Stephenson, 
+Marton Illes, Mate Farkas, Peter Kokai, Pontus Andersson, Sam Stephenson,
 Sebastian Roland, Viktor Juhasz, Zoltan Pallagi.
 

--- a/doc/man/syslog-ng.8.xml
+++ b/doc/man/syslog-ng.8.xml
@@ -318,7 +318,7 @@
         <link linkend="syslog-ng.conf.5"><command>syslog-ng.conf</command>(5)</link>
       </para>
       <note version="5.0">
-        <para>For the detailed documentation of  see <link xmlns:ns1="http://www.w3.org/1999/xlink" ns1:href="https://www.balabit.com/documents/syslog-ng-ose-latest-guides/en/syslog-ng-ose-guide-admin/html/index.html"><command>The  3.12 Administrator Guide</command></link></para>
+        <para>For the detailed documentation of  see <link xmlns:ns1="http://www.w3.org/1999/xlink" ns1:href="https://www.balabit.com/documents/syslog-ng-ose-latest-guides/en/syslog-ng-ose-guide-admin/html/index.html"><command>The  3.13 Administrator Guide</command></link></para>
         <para>If you experience any problems or need help with syslog-ng, visit the <link xmlns:ns1="http://www.w3.org/1999/xlink" ns1:href="https://lists.balabit.hu/mailman/listinfo/syslog-ng"><command>syslog-ng mailing list</command></link>.</para>
         <para>For news and notifications about of syslog-ng, visit the <link xmlns:ns1="http://www.w3.org/1999/xlink" ns1:href="https://syslog-ng.org/blogs/"><command>syslog-ng blogs</command></link>.</para>
       </note>


### PR DESCRIPTION
Hi,

Please do not forget to squash my commits if you like the result.
```
git rebase -i origin/master --autosquash
```

I've also changed another version number in `syslog-ng.8.xml`. Something is weird in this line, the word "syslog-ng" is missing from several places:

> For the detailed documentation of ~~syslog-ng~~ see The ~~syslog-ng~~  3.13 Administrator Guide