### PR TITLE
dqtool: assign - print the old entry in case of override

### DIFF
--- a/modules/diskq/dqtool.c
+++ b/modules/diskq/dqtool.c
@@ -583,6 +583,13 @@ dqtool_assign(int argc, char *argv[])
   const gchar *diskq_file = argv[optind];
   gchar *diskq_full_path = g_canonicalize_filename(diskq_file, NULL);
 
+  gchar *old_entry = persist_state_lookup_string(state, assign_persist_name, NULL, NULL);
+  if (old_entry)
+    {
+      fprintf(stderr, "Entry overrided during the assign process. Old entry: %s\n", old_entry);
+      g_free(old_entry);
+    }
+
   persist_state_alloc_string(state, assign_persist_name, diskq_full_path, -1);
   g_free(diskq_full_path);
 


### PR DESCRIPTION
My original intention was to only enable overriding if a "-f --force" option is provided, to prevent mistakes. I dropped that idea, because dqtool might be used from a script, and blocking the script is not a good idea.
But it might be handy if someone has the old entry nearby in case of accidental overrides.

Signed-off-by: Laszlo Szemere <laszlo.szemere@oneidentity.com>